### PR TITLE
Improve slider usability on touch-only devices

### DIFF
--- a/src/components/Adjuster/Adjuster.css
+++ b/src/components/Adjuster/Adjuster.css
@@ -134,26 +134,26 @@
   appearance: none;
   background-color: currentColor;
   border: 0;
-  border-radius: 1rem;
+  border-radius: 1.5rem;
   cursor: pointer;
-  height: 0.75rem;
-  margin-top: -0.3rem;
+  height: 1.6rem;
+  margin-top: -0.8rem;
   transition: 0.1s ease;
-  width: 0.75rem;
+  width: 1.6rem;
 }
 
 .adjusterValRange::-webkit-slider-thumb:hover,
 .adjusterValRange::-webkit-slider-thumb:active {
-  margin-top: -0.5rem;
-  height: 1.1rem;
-  width: 1.1rem;
+  margin-top: -1.8rem;
+  height: 2.5rem;
+  width: 2.5rem;
 }
 
 .adjusterValRange::-moz-range-thumb {
   appearance: none;
   background-color: currentColor;
   border: 0;
-  border-radius: 0.5rem;
+  border-radius: 1rem;
   cursor: pointer;
   height: 0.75rem;
   transition: 0.1s ease;
@@ -165,4 +165,20 @@
   margin-top: -0.5rem;
   height: 1.1rem;
   width: 1.1rem;
+}
+
+@media (hover) {
+  .adjusterValRange::-webkit-slider-thumb {
+    border-radius: 1rem;
+    height: 0.75rem;
+    margin-top: -0.3rem;
+    width: 0.75rem;
+  }
+
+  .adjusterValRange::-webkit-slider-thumb:hover,
+  .adjusterValRange::-webkit-slider-thumb:active {
+    margin-top: -0.5rem;
+    height: 1.1rem;
+    width: 1.1rem;
+  }
 }


### PR DESCRIPTION
Because the Adjusters are in a horizontally scrollable container, using the range sliders on touch devices can be tough or:

> My only thought is that it is nearly impossible to adjust the sliders on a mobile device.

This PR attempts to make them more usable by increasing the range thumb size for devices without `hover` support.

This is limited to browsers that recognize the `::-webkit-slider-thumb` selector. That's a non-standard selector for the range slider thumb.

With these changes, by default, the pertinent CSS for the thumb is:

```css
.adjusterValRange::-webkit-slider-thumb {
  ...
  height: 1.6rem;
  margin-top: -0.8rem;
  width: 1.6rem;
}

.adjusterValRange::-webkit-slider-thumb:hover,
.adjusterValRange::-webkit-slider-thumb:active {
  margin-top: -1.8rem;
  height: 2.5rem;
  width: 2.5rem;
}
```

I purposely set the `margin-top` on `:active` to make the thumb vertically off-center. This way there is more of a chance it won't be hidden behind the user's finger when they're using it.

Here's a screenshot from the iOS simulator showing the off-center and larger `:active` style of the thumb.
![screen shot 2017-01-06 at 9 53 04 am](https://cloud.githubusercontent.com/assets/233859/21721352/f697d094-d3f5-11e6-89f4-8ab29bad9dc4.png)

Because we only want the larger range thumb on non-hover devices, this uses the `hover` media query to provide a smaller thumb to those devices:

```css
@media (hover) {
  .adjusterValRange::-webkit-slider-thumb {
    ...
    height: 0.75rem;
    margin-top: -0.3rem;
    width: 0.75rem;
  }

  .adjusterValRange::-webkit-slider-thumb:hover,
  .adjusterValRange::-webkit-slider-thumb:active {
    margin-top: -0.5rem;
    height: 1.1rem;
    width: 1.1rem;
  }
}
```

`hover` is a new(er) media query: https://www.w3.org/TR/mediaqueries-4/#hover

