### PR TITLE
Changes CSS Color Function Package in Use

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "color": "1.0.3",
-    "css-color-function": "1.3.0",
+    "css-color-function": "tylergaw/css-color-function.git#tg-ignore-alpha-on-blend",
     "ramda": "0.23.0",
     "react": "15.4.1",
     "react-dom": "15.4.1"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "color": "1.0.3",
-    "css-color-function": "tylergaw/css-color-function.git#tg-ignore-alpha-on-blend",
+    "css-color-function": "tylergaw/css-color-function.git#tg-ignore-alpha-on-mix",
     "ramda": "0.23.0",
     "react": "15.4.1",
     "react-dom": "15.4.1"


### PR DESCRIPTION
fixes #3 

For right now, using my fork / branch of the css color function package https://github.com/tylergaw/css-color-function/tree/tg-ignore-alpha-on-mix to further test changes I'm PRing there.