### PR TITLE
Adds red, green, and blue adjusters

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -39,6 +39,21 @@ export const DEFAULT_ADJUSTERS = [
   },
   {
     enabled: false,
+    name: 'red',
+    max: 255
+  },
+  {
+    enabled: false,
+    name: 'green',
+    max: 255
+  },
+  {
+    enabled: false,
+    name: 'blue',
+    max: 255
+  },
+  {
+    enabled: false,
     name: 'whiteness',
     unit: '%',
     shortName: 'w'
@@ -49,6 +64,7 @@ export const DEFAULT_ADJUSTERS = [
     unit: '%',
     shortName: 'b'
   },
+
   {
     enabled: false,
     name: 'contrast',

--- a/src/utils/__tests__/color.test.js
+++ b/src/utils/__tests__/color.test.js
@@ -81,6 +81,24 @@ describe('#getAdjustersForColor', () => {
     },
     {
       enabled: false,
+      name: 'red',
+      max: 255,
+      value: 181
+    },
+    {
+      enabled: false,
+      name: 'green',
+      max: 255,
+      value: 119
+    },
+    {
+      enabled: false,
+      name: 'blue',
+      max: 255,
+      value: 242
+    },
+    {
+      enabled: false,
       name: 'whiteness',
       unit: '%',
       shortName: 'w',


### PR DESCRIPTION
fixes #2 

This PR adds support for the individual `red`, `green`, and `blue` adjusters. They operate directly on each channel.

Because we know the starting r, g, and b values we do not use a unit. This means:

> If there is no operator, the given channel is set to the given value. 

[css-color/#rgba-adjusters](https://drafts.csswg.org/css-color/#rgba-adjusters)

![](https://cl.ly/3L3p1e0i2N2j/Screen%20Recording%202017-01-10%20at%2001.23%20AM.gif)