### PR TITLE
Adds support for hsl, hsla, rrggbbaa, rgba formats

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "css-color-function": "tylergaw/css-color-function.git#tg-ignore-alpha-on-mix",
     "ramda": "0.23.0",
     "react": "15.4.1",
-    "react-dom": "15.4.1"
+    "react-dom": "15.4.1",
+    "tinycolor2": "1.4.1"
   },
   "scripts": {
     "start": "NODE_PATH=src react-scripts start",

--- a/src/App.js
+++ b/src/App.js
@@ -172,7 +172,7 @@ class App extends Component {
       adjusters: nextAdjusters,
       colorFuncStr: nextColorFuncStr,
       colorObj,
-      outputColor: outputColor,
+      outputColor,
       outputColorDisplay: outputFormats[nextSelectedFormat],
       outputContrastColor,
       selectedFormat: nextSelectedFormat

--- a/src/App.js
+++ b/src/App.js
@@ -5,17 +5,13 @@ import {
 import React, { Component } from 'react';
 import {findIndex, propEq} from 'ramda';
 import {
-  getAdjustersString,
   getColorFromQueryVal,
-  getColorFuncString,
   getColorObj,
-  getContrastColor,
 } from 'utils/color';
 
 import Banner from 'components/Banner';
 import Colors from 'components/Colors';
 import Controls from 'components/Controls';
-import colorFn from 'css-color-function';
 
 class App extends Component {
   constructor(props) {
@@ -48,6 +44,7 @@ class App extends Component {
       baseColorDisplay: ogBase,
       baseContrastColor: colorObj.baseContrastColor,
       colorFuncStr: colorObj.colorFuncStr,
+      colorObj,
       outputColor: ogBase,
       outputContrastColor: colorObj.outputContrastColor,
       useShortNames
@@ -63,16 +60,30 @@ class App extends Component {
     const colorObj = getColorObj(nextBaseColor);
 
     if (colorObj.isValid) {
-      const baseFormat = colorObj.baseColor.format;
+      const {
+        adjusters,
+        baseColor: {
+          format: baseFormat
+        },
+        baseContrastColor,
+        colorFuncStr,
+        colorFuncStrShortNames,
+        outputColor,
+        outputContrastColor
+      } = colorObj;
+
+      const nextColorFuncStr = useShortNames ? colorFuncStrShortNames :
+        colorFuncStr;
 
       this.setState({
-        adjusters: colorObj.adjusters,
+        adjusters,
         baseColor: nextBaseColor,
         baseColorDisplay: nextBaseColor,
-        baseContrastColor: colorObj.baseContrastColor,
-        colorFuncStr: colorObj.colorFuncStr,
-        outputColor: colorObj.outputColor[baseFormat],
-        outputContrastColor: colorObj.outputContrastColor
+        baseContrastColor,
+        colorFuncStr: nextColorFuncStr,
+        colorObj,
+        outputColor: outputColor[baseFormat],
+        outputContrastColor
       });
     } else {
       this.setState({
@@ -105,15 +116,26 @@ class App extends Component {
       }
     }
 
-    const adjustersStr = getAdjustersString(nextAdjusters, useShortNames);
-    const colorFuncStr = getColorFuncString(baseColor, adjustersStr);
-    const outputColor = colorFn.convert(colorFuncStr) || baseColor;
+    const colorObj = getColorObj(baseColor, nextAdjusters);
+    const {
+      baseColor: {
+        format: baseFormat
+      },
+      colorFuncStr,
+      colorFuncStrShortNames,
+      outputColor,
+      outputContrastColor
+    } = colorObj;
+
+    const nextColorFuncStr = useShortNames ? colorFuncStrShortNames :
+      colorFuncStr;
 
     this.setState({
       adjusters: nextAdjusters,
-      colorFuncStr,
-      outputColor,
-      outputContrastColor: getContrastColor(outputColor)
+      colorFuncStr: nextColorFuncStr,
+      colorObj,
+      outputColor: outputColor[baseFormat],
+      outputContrastColor
     });
   }
 
@@ -123,8 +145,10 @@ class App extends Component {
     }
 
     const {
-      adjusters,
-      baseColor,
+      colorObj: {
+        colorFuncStr,
+        colorFuncStrShortNames
+      },
       useShortNames
     } = this.state;
 
@@ -133,11 +157,13 @@ class App extends Component {
     } = window;
 
     const nextUseShortNames = !useShortNames;
+    const nextColorFuncStr = nextUseShortNames ? colorFuncStrShortNames :
+      colorFuncStr;
+
     localStorage.setItem(SHORT_NAMES_KEY, nextUseShortNames);
 
     this.setState({
-      colorFuncStr: getColorFuncString(baseColor,
-        getAdjustersString(adjusters, nextUseShortNames)),
+      colorFuncStr: nextColorFuncStr,
       useShortNames: nextUseShortNames
     });
   }

--- a/src/components/Banner/Banner.css
+++ b/src/components/Banner/Banner.css
@@ -18,7 +18,7 @@
   padding-top: 0.22rem;
 }
 
-@media (min-width: 43em) {
+@media (min-width: 45em) {
   [role='banner'] {
     display: flex;
   }

--- a/src/components/Colors/Colors.css
+++ b/src/components/Colors/Colors.css
@@ -20,14 +20,14 @@
 
 .colorInfo {
   flex-basis: 100%;
-  max-width: 21rem;
+  max-width: 22.5rem;
   z-index: 10;
 }
 
 .colorInput {
   border: 0;
   border-bottom: 1px solid currentColor;
-  font-size: 1.4rem;
+  font-size: 1.1rem;
   margin-top: 1rem;
   padding: 0.5rem 0;
 }
@@ -36,8 +36,32 @@
   outline: none;
 }
 
-@media (min-width: 43em) {
+.colorInputLabel {
+  display: block;
+  font-size: 1rem;
+  line-height: 1.4;
+  margin-top: 0.4rem;
+  opacity: 0.8;
+}
+
+@media (min-width: 24em) {
+  .colorInput {
+    font-size: 1.4rem;
+  }
+}
+
+@media (min-width: 45em) {
   .colorContainer {
     flex-basis: 50%;
+  }
+
+  .colorInput {
+    font-size: 1.2rem;
+  }
+}
+
+@media (min-width: 50em) {
+  .colorInput {
+    font-size: 1.4rem;
   }
 }

--- a/src/components/Colors/Colors.js
+++ b/src/components/Colors/Colors.js
@@ -2,14 +2,19 @@ import './Colors.css';
 
 import React, {Component, PropTypes} from 'react';
 
+import FormatSelect from './FormatSelect';
+
 class Colors extends Component {
   static propTypes = {
-    baseColor: PropTypes.string.isRequired,
+    baseColor: PropTypes.object.isRequired,
     baseColorDisplay: PropTypes.string.isRequired,
     baseColorOnChange: PropTypes.func,
     baseContrastColor: PropTypes.string.isRequired,
-    outputColor: PropTypes.string.isRequired,
-    outputContrastColor: PropTypes.string.isRequired
+    outputColor: PropTypes.object.isRequired,
+    outputColorDisplay: PropTypes.string.isRequired,
+    outputContrastColor: PropTypes.string.isRequired,
+    selectedFormat: PropTypes.string.isRequired,
+    selectedFormatOnChange: PropTypes.func
   }
 
   static defaultProps = {
@@ -20,22 +25,36 @@ class Colors extends Component {
     const {
       baseContrastColor,
       baseColor,
+      baseColor: {
+        format: baseFormat
+      },
       baseColorDisplay,
       baseColorOnChange,
       outputColor,
-      outputContrastColor
+      outputColorDisplay,
+      outputContrastColor,
+      selectedFormat,
+      selectedFormatOnChange
     } = this.props;
+
+    const formatSelectProps = {
+      baseFormat,
+      outputColor,
+      selectedFormat,
+      selectedFormatOnChange
+    };
 
     return (
       <div className='colors'>
         <div className='colorContainer baseColorContainer'
           style={{
-            backgroundColor: baseColor,
+            backgroundColor: baseColor.original,
             color: baseContrastColor
           }}>
 
           <div className='colorInfo'>
             <input className='resetInput colorInput'
+              id='inputColor'
               style={{
                 color: baseContrastColor
               }}
@@ -46,13 +65,16 @@ class Colors extends Component {
               autoCapitalize='off'
               spellCheck='false'
               onChange={baseColorOnChange} />
-            <small>Base hex, rgb(a), or keyword color</small>
+            <label className='colorInputLabel'
+              htmlFor='inputColor'>
+              hex, rrggbbaa, rgb(a), hsl(a) or keyword color
+            </label>
           </div>
         </div>
 
         <div className='colorContainer outputColorContainer'
           style={{
-            backgroundColor: outputColor,
+            backgroundColor: outputColor.original,
             color: outputContrastColor
           }}>
           <div className='colorInfo'>
@@ -62,8 +84,11 @@ class Colors extends Component {
               }}
               type='text'
               readOnly
-              value={outputColor} />
-            <small>Output color</small>
+              value={outputColorDisplay} />
+            <label className='colorInputLabel'>
+              Output color as
+              <FormatSelect {...formatSelectProps} />
+            </label>
           </div>
         </div>
       </div>

--- a/src/components/Colors/Colors.js
+++ b/src/components/Colors/Colors.js
@@ -4,24 +4,24 @@ import React, {Component, PropTypes} from 'react';
 
 class Colors extends Component {
   static propTypes = {
-    inputColor: PropTypes.string.isRequired,
-    inputColorDisplay: PropTypes.string.isRequired,
-    inputColorOnChange: PropTypes.func,
-    inputContrastColor: PropTypes.string.isRequired,
+    baseColor: PropTypes.string.isRequired,
+    baseColorDisplay: PropTypes.string.isRequired,
+    baseColorOnChange: PropTypes.func,
+    baseContrastColor: PropTypes.string.isRequired,
     outputColor: PropTypes.string.isRequired,
     outputContrastColor: PropTypes.string.isRequired
   }
 
   static defaultProps = {
-    inputColorOnChange: () => {}
+    baseColorOnChange: () => {}
   }
 
   render() {
     const {
-      inputColor,
-      inputColorDisplay,
-      inputColorOnChange,
-      inputContrastColor,
+      baseContrastColor,
+      baseColor,
+      baseColorDisplay,
+      baseColorOnChange,
       outputColor,
       outputContrastColor
     } = this.props;
@@ -30,22 +30,22 @@ class Colors extends Component {
       <div className='colors'>
         <div className='colorContainer baseColorContainer'
           style={{
-            backgroundColor: inputColor,
-            color: inputContrastColor
+            backgroundColor: baseColor,
+            color: baseContrastColor
           }}>
 
           <div className='colorInfo'>
             <input className='resetInput colorInput'
               style={{
-                color: inputContrastColor
+                color: baseContrastColor
               }}
               type='text'
-              value={inputColorDisplay}
+              value={baseColorDisplay}
               autoComplete='off'
               autoCorrect='off'
               autoCapitalize='off'
               spellCheck='false'
-              onChange={inputColorOnChange} />
+              onChange={baseColorOnChange} />
             <small>Base hex, rgb(a), or keyword color</small>
           </div>
         </div>

--- a/src/components/Colors/FormatSelect.css
+++ b/src/components/Colors/FormatSelect.css
@@ -1,0 +1,29 @@
+.formatSelectContainer {
+  box-shadow: 0 1px 0 currentColor;
+  display: inline-block;
+  margin-left: 0.3rem;
+  position: relative;
+}
+
+.formatSelectIcon {
+  fill: currentColor;
+  position: absolute;
+  right: 0;
+  top: 0.12rem;
+  z-index: 1;
+}
+
+.formatSelect {
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  border-radius: 0;
+  color: currentColor;
+  cursor: pointer;
+  display: inline-block;
+  font-family: 'Karla', helvetica, sans-serif;
+  font-size: 1rem;
+  padding-right: 1.5rem;
+  position: relative;
+  z-index: 2;
+}

--- a/src/components/Colors/FormatSelect.css
+++ b/src/components/Colors/FormatSelect.css
@@ -27,3 +27,11 @@
   position: relative;
   z-index: 2;
 }
+
+.formatSelect optgroup {
+  -moz-appearance: menupopup;
+  font-family: 'Karla', helvetica, sans-serif;
+  color: #252525;
+  font-style: normal;
+  padding: 0.25rem;
+}

--- a/src/components/Colors/FormatSelect.js
+++ b/src/components/Colors/FormatSelect.js
@@ -1,0 +1,95 @@
+import './FormatSelect.css';
+
+import React, {Component, PropTypes} from 'react';
+
+class FormatSelect extends Component {
+  static propTypes = {
+    baseFormat: PropTypes.string.isRequired,
+    outputColor: PropTypes.object.isRequired,
+    selectedFormat: PropTypes.string.isRequired,
+    selectedFormatOnChange: PropTypes.func
+  }
+
+  static defaultProps = {
+    selectedFormatOnChange: () => {}
+  }
+
+  allFormatsAndOrder = [
+    'hex',
+    'hex3',
+    'hex8',
+    'hex4',
+    'rgb',
+    'hsl',
+    'keyword'
+  ];
+
+  friendlyLabels = {
+    hex3: 'hex (short)',
+    hex4: 'rrggbbaa (short)',
+    hex8: 'rrggbbaa',
+    rgb: 'rgb(a)',
+    hsl: 'hsl(a)'
+  }
+
+  render() {
+    const {
+      outputColor: {
+        formats
+      },
+      selectedFormat,
+      selectedFormatOnChange
+    } = this.props;
+
+    const availableFormats = this.allFormatsAndOrder.filter(f => !!formats[f]);
+    const unavailableFormats = this.allFormatsAndOrder.filter(f => !formats[f]);
+
+    const available = (
+      <optgroup label='Available formats'>
+      {
+        availableFormats.map(f => {
+          return (
+            <option key={`format${f}`} value={f}>
+              {this.friendlyLabels[f] || f}
+            </option>
+          );
+        })
+      }
+      </optgroup>
+    );
+
+    const unavailable = unavailableFormats.length ? (
+      <optgroup label='Unavailable formats' disabled>
+      {
+        unavailableFormats.map(f => {
+          return (
+            <option key={`format${f}`}>
+              {this.friendlyLabels[f] || f}
+            </option>
+          );
+        })
+      }
+      </optgroup>
+    ) : '';
+
+    return (
+      <span className='formatSelectContainer'>
+        <select className='formatSelect'
+          onChange={selectedFormatOnChange}
+          value={selectedFormat}>
+          {available}
+          {unavailable}
+        </select>
+        <svg className='formatSelectIcon'
+          xmlns='http://www.w3.org/2000/svg'
+          width='20'
+          height='20'
+          viewBox='0 0 20 20'>
+          <path d='M10 7.75H5.67l2.165 2.625L10 13l2.165-2.625L14.33 7.75'/>
+        </svg>
+      </span>
+    );
+  };
+}
+
+export default FormatSelect;

--- a/src/components/Colors/FormatSelect.js
+++ b/src/components/Colors/FormatSelect.js
@@ -63,7 +63,7 @@ class FormatSelect extends Component {
       {
         unavailableFormats.map(f => {
           return (
-            <option key={`format${f}`}>
+            <option key={`format${f}`} disabled>
               {this.friendlyLabels[f] || f}
             </option>
           );

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,15 +9,15 @@ export const DEFAULT_ADJUSTERS = [
   },
   {
     enabled: false,
-    name: 'saturation',
-    unit: '%',
-    shortName: 's'
-  },
-  {
-    enabled: false,
     name: 'hue',
     max: 360,
     shortName: 'h'
+  },
+  {
+    enabled: false,
+    name: 'saturation',
+    unit: '%',
+    shortName: 's'
   },
   {
     enabled: false,

--- a/src/index.css
+++ b/src/index.css
@@ -97,14 +97,14 @@ main {
   width: 100%;
 }
 
-@media (min-height: 40em) and (max-width: 43em) {
+@media (min-height: 40em) and (max-width: 45em) {
   main {
     flex-wrap: nowrap;
     flex-direction: column;
   }
 }
 
-@media (min-height: 27em) and (min-width: 43em) {
+@media (min-height: 27em) and (min-width: 45em) {
   main {
     flex-wrap: nowrap;
     flex-direction: column;

--- a/src/utils/__tests__/color.test.js
+++ b/src/utils/__tests__/color.test.js
@@ -3,6 +3,7 @@ import * as C from '../color';
 import {
   DEFAULT_ADJUSTERS,
 } from '../../constants';
+import tinycolor from 'tinycolor2';
 
 describe('#getHslObjFromStr', () => {
   it('gets the correct object for an hsl string', () => {
@@ -379,4 +380,55 @@ describe('#getAdjustersString', () => {
     adjusters[4].value = '20';
     expect(C.getAdjustersString(adjusters, true).trim()).toEqual('a(60%) s(80%) tint(20%)');
   });
+});
+
+describe.only('#getColorFormats', () => {
+  // Convenience method.
+  const formatsList = colorObj => Object.keys(
+    C.getColorFormats(colorObj).formats);
+
+  const color1 = tinycolor('black');
+  expect(formatsList(color1)).toEqual([
+    'hex',
+    'hex3',
+    'hex4',
+    'hex8',
+    'hsl',
+    'keyword',
+    'rgb'
+  ]);
+
+  const color2 = tinycolor('rgba(300, 100, 70, 0.9)');
+  expect(formatsList(color2)).toEqual([
+    'hex8',
+    'hsl',
+    'rgb'
+  ]);
+
+  const color3 = tinycolor('#51a129');
+  expect(formatsList(color3)).toEqual([
+    'hex',
+    'hex8',
+    'hsl',
+    'rgb'
+  ]);
+
+  const color4 = tinycolor('hsl(300, 20%, 40%)');
+  expect(formatsList(color4)).toEqual([
+    'hex',
+    'hex8',
+    'hsl',
+    'rgb'
+  ]);
+
+  const color5 = tinycolor('hsl(360, 100%, 50%)');
+  expect(formatsList(color5)).toEqual([
+    'hex',
+    'hex3',
+    'hex4',
+    'hex8',
+    'hsl',
+    'keyword',
+    'rgb'
+  ]);
 });

--- a/src/utils/__tests__/color.test.js
+++ b/src/utils/__tests__/color.test.js
@@ -4,35 +4,128 @@ import {
   DEFAULT_ADJUSTERS,
 } from '../../constants';
 
+describe('#getHslObjFromStr', () => {
+  it('gets the correct object for an hsl string', () => {
+    expect(C.getHslObjFromStr('hsl(270, 82%, 70%)')).toEqual({
+      h: 270,
+      s: 82,
+      l: 70
+    });
+  });
+
+  it('gets the correct object for an hsla string', () => {
+    expect(C.getHslObjFromStr('hsla(301, 81%, 54%, 0.45)')).toEqual({
+      h: 301,
+      s: 81,
+      l: 54
+    });
+  });
+});
+
 describe('#getColorProperties', () => {
   const hex = '#b577f2';
   const rgb = 'rgb(181, 119, 242)';
-  const rgba = 'rgb(181, 119, 242, 0.6)';
+  const rgba = 'rgba(181, 119, 242, 0.6)';
+  const hsl = 'hsl(270, 82%, 70%)';
+  const hsla = 'hsla(270, 82%, 70%, 0.45)';
 
   let expectedProps = {
     alpha: 100,
-    hue: 271,
-    lightness: 71,
-    saturation: 83,
-    blackness: 6,
-    whiteness: 47,
+    hue: 270,
+    lightness: 70,
+    saturation: 82,
+    blackness: 5,
+    whiteness: 46,
     red: 181,
     green: 119,
     blue: 242
   };
 
   it('gets the correct props and values for a hex color', () => {
-    expect(C.getColorProperties(hex)).toEqual(expectedProps);
+    const props = C.getColorProperties(hex);
+    expect(props).toEqual(expectedProps);
   });
 
-  it('gets the correct props and values for a rgb color', () => {
-    expect(C.getColorProperties(rgb)).toEqual(expectedProps);
+  it('gets the correct props and values for an rgb color', () => {
+    const props = C.getColorProperties(rgb);
+    expect(props).toEqual(expectedProps);
   });
 
-  it('gets the correct props and values for a rgba color', () => {
+  it('gets the correct props and values for an rgba color', () => {
     let expectedRgbaProps = {...expectedProps};
     expectedRgbaProps.alpha = 60;
-    expect(C.getColorProperties(rgba)).toEqual(expectedRgbaProps);
+    const props = C.getColorProperties(rgba);
+    expect(props).toEqual(expectedRgbaProps);
+  });
+
+  it('gets the correct props and values for an hsl color', () => {
+    const expectedProps = {
+      alpha: 100,
+      hue: 270,
+      lightness: 70,
+      saturation: 82,
+      blackness: 5,
+      whiteness: 45,
+      red: 178,
+      green: 115,
+      blue: 241
+    };
+
+    const props = C.getColorProperties(hsl);
+    expect(props).toEqual(expectedProps);
+  });
+
+  it('gets the correct props and values for an hsla color', () => {
+    const expectedProps = {
+      alpha: 45,
+      hue: 270,
+      lightness: 70,
+      saturation: 82,
+      blackness: 5,
+      whiteness: 45,
+      red: 178,
+      green: 115,
+      blue: 241
+    };
+
+    const props = C.getColorProperties(hsla);
+    expect(props).toEqual(expectedProps);
+  });
+
+  it('should never change values from what was input', () => {
+    const hsl = 'hsl(100, 19%, 20%)';
+    const hslTwo = 'hsl(110, 21%, 20%)';
+
+    const expectedProps = {
+      alpha: 100,
+      hue: 100,
+      lightness: 20,
+      saturation: 19,
+      blackness: 76,
+      whiteness: 16,
+      red: 47,
+      green: 60,
+      blue: 41
+    };
+
+    const props = C.getColorProperties(hsl);
+
+    const expectedPropsTwo = {
+      alpha: 100,
+      hue: 110,
+      lightness: 20,
+      saturation: 21,
+      blackness: 75,
+      whiteness: 15,
+      red: 43,
+      green: 61,
+      blue: 40
+    };
+
+    const propsTwo = C.getColorProperties(hslTwo);
+
+    expect(props).toEqual(expectedProps);
+    expect(propsTwo).toEqual(expectedPropsTwo);
   });
 });
 
@@ -48,24 +141,24 @@ describe('#getAdjustersForColor', () => {
     },
     {
       enabled: false,
-      name: 'saturation',
-      unit: '%',
-      shortName: 's',
-      value: 83
-    },
-    {
-      enabled: false,
       name: 'hue',
       max: 360,
       shortName: 'h',
-      value: 271
+      value: 270
+    },
+    {
+      enabled: false,
+      name: 'saturation',
+      unit: '%',
+      shortName: 's',
+      value: 82
     },
     {
       enabled: false,
       name: 'lightness',
       unit: '%',
       shortName: 'l',
-      value: 71
+      value: 70
     },
     {
       enabled: false,
@@ -102,14 +195,14 @@ describe('#getAdjustersForColor', () => {
       name: 'whiteness',
       unit: '%',
       shortName: 'w',
-      value: 47
+      value: 46
     },
     {
       enabled: false,
       name: 'blackness',
       unit: '%',
       shortName: 'b',
-      value: 6
+      value: 5
     },
     {
       enabled: false,
@@ -278,8 +371,8 @@ describe('#getAdjustersString', () => {
     adjusters[0].value = '60';
 
     // saturation | s
-    adjusters[1].enabled = true;
-    adjusters[1].value = '80';
+    adjusters[2].enabled = true;
+    adjusters[2].value = '80';
 
     // tint
     adjusters[4].enabled = true;

--- a/src/utils/__tests__/color.test.js
+++ b/src/utils/__tests__/color.test.js
@@ -127,22 +127,37 @@ describe('#getAdjustersForColor', () => {
 describe('#getColorFromQueryVal', () => {
   const hash = '#8421e6';
   const hashThree = '#842';
+  const hashFour = '#f00b';
+  const hashEight = '#ff0000bf';
 
   const hex = '8421e6';
-  const encoded = '%238421e6';
-  const encodedThree = '%23842';
+  const hexThree = '842';
+  const hexFour = 'f00b';
+  const hexEight = 'ff0000bf';
+
+  const hexEnc = '%238421e6';
+  const hexThreeEnc = '%23842';
+  const hexFourEnc = '%23f00b';
+  const hexEightEnc = '%23ff0000bf';
 
   const rgb = 'rgb(181, 119, 242)';
-  const encodedRgb = 'rgb(181,%20119,%20242)';
   const rgba = 'rgb(181, 119, 242, 0.6)';
-  const encodedRgba = 'rgb(181,%20119,%20242,%200.6)';
+  const rgbEnc = 'rgb(181,%20119,%20242)';
+  const rgbaEnc = 'rgb(181,%20119,%20242,%200.6)';
 
+  const hsl = 'hsl(100, 19%, 20%)';
+  const hsla = 'hsla(100, 19%, 20%, 0.6)';
+  const hslEnc = 'hsl(100,%2019%25,%2020%25)';
+  const hslaEnc = 'hsla(100,%2019%25,%2020%25,%200.6)';
+
+  // Keyword colors
   it('gets the correct color from keyword colors', () => {
     expect(C.getColorFromQueryVal('red')).toEqual('red');
     expect(C.getColorFromQueryVal('yellow')).toEqual('yellow');
     expect(C.getColorFromQueryVal('navy')).toEqual('navy');
   });
 
+  // Hex values including un-encoded "#" char
   it('gets the correct color from a hex with an un-encoded url hash', () => {
     expect(C.getColorFromQueryVal(hash)).toEqual(hash);
   });
@@ -151,26 +166,68 @@ describe('#getColorFromQueryVal', () => {
     expect(C.getColorFromQueryVal(hashThree)).toEqual(hashThree);
   });
 
-  it('gets the correct color from a hex without a hash', () => {
+  it('gets the correct color from a 4 digit hex with an un-encoded url hash', () => {
+    expect(C.getColorFromQueryVal(hashFour)).toEqual(hashFour);
+  });
+
+  it('gets the correct color from a 8 digit hex with an un-encoded url hash', () => {
+    expect(C.getColorFromQueryVal(hashEight)).toEqual(hashEight);
+  });
+
+  // Hex values that do not include a "#" char
+  it('gets the correct color from a hex without a # char', () => {
     expect(C.getColorFromQueryVal(hex)).toEqual(hash);
   });
 
-  it('gets the correct color from a hex with url encoded hash', () => {
-    expect(C.getColorFromQueryVal(encoded)).toEqual(hash);
+  it('gets the correct color from a 3 digit hex without a # char', () => {
+    expect(C.getColorFromQueryVal(hexThree)).toEqual(hashThree);
   });
 
-  it('gets the correct color from a 3-digit hex with url encoded hash', () => {
-    expect(C.getColorFromQueryVal(encodedThree)).toEqual(hashThree);
+  it('gets the correct color from a 4 digit hex without a # char', () => {
+    expect(C.getColorFromQueryVal(hexFour)).toEqual(hashFour);
   });
 
-  it('gets the correct color for an un-encoded rgb(a) strings', () => {
+  it('gets the correct color from an 8 digit hex without a # char', () => {
+    expect(C.getColorFromQueryVal(hexEight)).toEqual(hashEight);
+  });
+
+  // Hex values that include a url encoded "#" (%23) char
+  it('gets the correct color from a hex with url encoded # char', () => {
+    expect(C.getColorFromQueryVal(hexEnc)).toEqual(hash);
+  });
+
+  it('gets the correct color from a 3 digit hex with url encoded # char', () => {
+    expect(C.getColorFromQueryVal(hexThreeEnc)).toEqual(hashThree);
+  });
+
+  it('gets the correct color from a 4 digit hex with url encoded # char', () => {
+    expect(C.getColorFromQueryVal(hexFourEnc)).toEqual(hashFour);
+  });
+
+  it('gets the correct color from a 8 digit hex with url encoded # char', () => {
+    expect(C.getColorFromQueryVal(hexEightEnc)).toEqual(hashEight);
+  });
+
+  // rgb values
+  it('gets the correct color from un-encoded rgb(a) strings', () => {
     expect(C.getColorFromQueryVal(rgb)).toEqual(rgb);
     expect(C.getColorFromQueryVal(rgba)).toEqual(rgba);
   });
 
-  it('gets the correct color for an encoded rgb(a) strings', () => {
-    expect(C.getColorFromQueryVal(encodedRgb)).toEqual(rgb);
-    expect(C.getColorFromQueryVal(encodedRgba)).toEqual(rgba);
+  it('gets the correct color from encoded rgb(a) strings', () => {
+    expect(C.getColorFromQueryVal(rgbEnc)).toEqual(rgb);
+    expect(C.getColorFromQueryVal(rgbaEnc)).toEqual(rgba);
+  });
+
+  // hsl values
+  it('gets the correct color from un-encoded hsl(a) strings', () => {
+    expect(C.getColorFromQueryVal(hsl)).toEqual(hsl);
+    expect(C.getColorFromQueryVal(hsla)).toEqual(hsla);
+  });
+
+  it('gets the correct color from encoded hsl(a) strings', () => {
+    expect(C.getColorFromQueryVal(hslEnc)).toEqual(hsl);
+    expect(C.getColorFromQueryVal(hslaEnc)).toEqual(hsla);
   });
 });
 

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -331,10 +331,13 @@ export const getColorObj = (colorStr, adjusters = DEFAULT_ADJUSTERS) => {
       // NOTE: `css-color-function` package can't work with rrggbbaa format.
       // so we use the rgb value.
       colorFnResult = (baseColor.format === 'hex8') ?
-        colorFn.convert(getColorFuncString(baseColor.rgb, adjustersStr)) :
+        colorFn.convert(getColorFuncString(baseColor.formats.rgb, adjustersStr)) :
         colorFn.convert(colorFuncStr);
     } catch (e) {
       colorFnResult = baseColor.original;
+      if (process.env.NODE_ENV === 'development') {
+        console.warn('In getColorObj:', e);
+      }
     }
 
     const convertedColor = tinycolor(colorFnResult);

--- a/src/utils/color.js
+++ b/src/utils/color.js
@@ -205,7 +205,9 @@ export const getColorObj = (colorStr, adjusters = DEFAULT_ADJUSTERS) => {
 
     // NOTE: `color` package can't work with rrggbbaa or hsl color formats.
     // getAdjustersForColor uses it and needs an rbg(a) format or it will die.
-    const newAdjusters = getAdjustersForColor(baseColor.rgb, adjusters);
+    const newAdjusters = (adjusters === DEFAULT_ADJUSTERS) ?
+      getAdjustersForColor(baseColor.rgb, adjusters) : adjusters;
+
     const adjustersStr = getAdjustersString(newAdjusters);
     const adjustersStrShortNames = getAdjustersString(newAdjusters, true);
     const colorFuncStr = getColorFuncString(colorStr, adjustersStr);


### PR DESCRIPTION
fixes #9 

This PR adds support for `hsl(a)`, `rrggbbaa`, and the shorthand for `rrggbbaa` color formats for base colors. It also adds a UI to choose which format you see for the output color.

![animated gif showing new functionality](https://cl.ly/0T2J132B2V0I/Screen%20Recording%202017-01-17%20at%2004.51%20PM.gif)