### PR TITLE
Adds a color picker for the base color

### DIFF
--- a/src/components/Colors/Colors.css
+++ b/src/components/Colors/Colors.css
@@ -21,6 +21,7 @@
 .colorInfo {
   flex-basis: 100%;
   max-width: 22.5rem;
+  position: relative;
   z-index: 10;
 }
 
@@ -42,6 +43,43 @@
   line-height: 1.4;
   margin-top: 0.4rem;
   opacity: 0.8;
+}
+
+.colorPickerContainer {
+  display: block;
+  height: 28px;
+  position: absolute;
+  right: 0;
+  top: 1.5rem;
+  transition: opacity 0.1s;
+  width: 24px;
+}
+
+.colorPickerContainer:hover,
+.colorPickerContainer:focus {
+  opacity: 0.8;
+}
+
+.colorPickerContainer:hover svg,
+.colorPickerContainer:focus svg {
+  transform: scale3d(0.9, 0.9, 1);
+}
+
+.colorPickerContainer input {
+  appearance: none;
+  background-color: transparent;
+  border: 0;
+  cursor: pointer;
+  height: 30px;
+  opacity: 0;
+  position: absolute;
+  width: 24px;
+}
+
+.colorPickerContainer svg {
+  pointer-events: none;
+  transform: scale3d(0.8, 0.8, 1);
+  transition: transform 0.1s;
 }
 
 @media (min-width: 24em) {

--- a/src/components/Colors/Colors.js
+++ b/src/components/Colors/Colors.js
@@ -75,9 +75,25 @@ class Colors extends Component {
     // "The value property of the input must be a 7 character long string" - MDN
     const colorPickerHex = hex8.substr(0, 7);
     const colorPickerInput = colorInputSupport ? (
-      <input type='color'
-        value={colorPickerHex}
-        onChange={baseColorOnChange} />
+      <div className='colorPickerContainer'>
+        <input type='color'
+          value={colorPickerHex}
+          onChange={baseColorOnChange} />
+
+        <svg xmlns='http://www.w3.org/2000/svg'
+          viewBox='0 0 24 30'
+          width='24'
+          height='30'>
+          <title>
+            A color picker icon
+          </title>
+          <description>
+            Icon by Denis Klyuchnikov from the Noun Project
+          </description>
+          <path fill={baseContrastColor}
+            d='M1 20.303c0 1.467 1.125 2.667 2.5 2.667S6 21.77 6 20.303c0-1.467-2.5-5.333-2.5-5.333S1 18.836 1 20.303zm20.085-10.54l-5.877-5.878c-.392-.392-.86-.658-1.36-.798l.92-.92c.316-.315.315-.82.003-1.133-.31-.314-.82-.31-1.13.003L9.825 4.85c-.014.015-.028.03-.04.046l-4.87 4.866c-1.22 1.22-1.22 3.197 0 4.416l5.878 5.877c1.22 1.22 3.2 1.22 4.42 0l5.876-5.877c1.22-1.22 1.22-3.197 0-4.416zM5.6 12c0-.39.15-.78.447-1.077l5.876-5.876c.596-.596 1.558-.596 2.154 0l5.876 5.876c.298.298.447.687.447 1.077H5.6z' />
+        </svg>
+      </div>
     ) : '';
 
     return (

--- a/src/components/Colors/Colors.js
+++ b/src/components/Colors/Colors.js
@@ -21,12 +21,39 @@ class Colors extends Component {
     baseColorOnChange: () => {}
   }
 
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      colorInputSupport: false
+    };
+  }
+
+  componentDidMount() {
+    const test = document.createElement('input');
+    test.type = 'color';
+    test.value = 'test';
+    // Browsers with input[type='color'] will not set this value.
+    const colorInputSupport = test.value !== 'test';
+
+    this.setState({
+      colorInputSupport
+    });
+  }
+
   render() {
     const {
+      colorInputSupport
+    } = this.state;
+
+    const {
       baseContrastColor,
-      baseColor,
       baseColor: {
-        format: baseFormat
+        format: baseFormat,
+        formats: {
+          hex8
+        },
+        original: ogBase
       },
       baseColorDisplay,
       baseColorOnChange,
@@ -44,15 +71,26 @@ class Colors extends Component {
       selectedFormatOnChange
     };
 
+    // For the color picker input
+    // "The value property of the input must be a 7 character long string" - MDN
+    const colorPickerHex = hex8.substr(0, 7);
+    const colorPickerInput = colorInputSupport ? (
+      <input type='color'
+        value={colorPickerHex}
+        onChange={baseColorOnChange} />
+    ) : '';
+
     return (
       <div className='colors'>
         <div className='colorContainer baseColorContainer'
           style={{
-            backgroundColor: baseColor.original,
+            backgroundColor: ogBase,
             color: baseContrastColor
           }}>
 
           <div className='colorInfo'>
+            {colorPickerInput}
+
             <input className='resetInput colorInput'
               id='inputColor'
               style={{


### PR DESCRIPTION
This PR adds a stylized `input[type=color]` for the base color.

There's feature detection in place so it will only show up if the browser supports color inputs.

![Animated gif showing the color picker in use on ColorMe](https://cl.ly/2T2n2J031a0H/Screen%20Recording%202017-01-21%20at%2012.25%20AM.gif)