### PR TITLE
Updates to OG css-color-function tag 1.3.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "color": "1.0.3",
-    "css-color-function": "tylergaw/css-color-function.git#tg-ignore-alpha-on-mix",
+    "css-color-function": "ianstormtaylor/css-color-function#1.3.1",
     "ramda": "0.23.0",
     "react": "15.4.1",
     "react-dom": "15.4.1",


### PR DESCRIPTION
Stops pointing to my fork of the package. Points to a tag in the og repo.

See https://github.com/ianstormtaylor/css-color-function/issues/26